### PR TITLE
fix: Fix radio on review write modal is not working

### DIFF
--- a/src/components/ModalComponents/LectureDetailPage/LectureReviewWriteModalComponent.js
+++ b/src/components/ModalComponents/LectureDetailPage/LectureReviewWriteModalComponent.js
@@ -68,6 +68,8 @@ const LectureReviewWriteModalComponent = () => {
       case "assignment_amount":
       case "difficulty":
       case "grade_portion":
+        setForm((prev) => ({ ...prev, [key]: value }));
+        return;
       case "assignment":
         if (form[key].some(({ id }) => id === value)) {
           if (form[key].length === 1) return;


### PR DESCRIPTION
Fix radios resembling select on review write modal is not working

## :bookmark_tabs: 제목

강의평가 작성 모달에서 Select같은 Radio들이 작동하지 않는 문제를 수정해습니다.

## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?